### PR TITLE
Fix dateTime bug

### DIFF
--- a/OneSGP4_Example/Program.cs
+++ b/OneSGP4_Example/Program.cs
@@ -64,7 +64,7 @@ namespace OneSGP4_Example
             sgp4Propagator.runSgp4Cal(startTime, stopTime, 1 / 30.0); // 1/60 => caclulate sat points every 2 seconds
             List<One_Sgp4.Sgp4Data> resultDataList = new List<Sgp4Data>();
             //Return Results containing satellite Position x,y,z (ECI-Coordinates in Km) and Velocity x_d, y_d, z_d (ECI-Coordinates km/s) 
-            resultDataList = sgp4Propagator.getRestults();
+            resultDataList = sgp4Propagator.getResults();
 
             startTime = new EpochTime(DateTime.Now);
             //Coordinate of an observer on Ground lat, long, height(in meters)

--- a/One_Sgp4/SatFunctions.cs
+++ b/One_Sgp4/SatFunctions.cs
@@ -95,7 +95,7 @@ namespace One_Sgp4
             r.y = satPosData.getY() - groundLocation.y;
             r.z = satPosData.getZ() - groundLocation.z;
 
-            double r_lat = coordinate.getLatetude() * toRadians;
+            double r_lat = coordinate.getLatitude() * toRadians;
 
             double sin_lat = Math.Sin(r_lat);
             double cos_lat = Math.Cos(r_lat);
@@ -226,7 +226,7 @@ namespace One_Sgp4
         {
             Sgp4 sgp4Propagator = new Sgp4(satellite, wgs);
             sgp4Propagator.runSgp4Cal(atTime, atTime, 1 / 60.0);
-            return sgp4Propagator.getRestults()[0];
+            return sgp4Propagator.getResults()[0];
         }
 
         //! Calculate Passes of a satellite for ceratin number of days from a starting time

--- a/One_Sgp4/ground/Coordinate.cs
+++ b/One_Sgp4/ground/Coordinate.cs
@@ -33,7 +33,7 @@ namespace One_Sgp4
         public const double toDegrees = 180.0 / pi; //!< double constant conversion to degree
         public const double toRadians = pi / 180.0; //!< double constant converstion to radians
 
-        private double latetude; //!< double Latetude in degree
+        private double latitude; //!< double Latetude in degree
         private double longitude; //!< double longitude in degree
         private double height; //!< double height in meters
 
@@ -43,10 +43,10 @@ namespace One_Sgp4
         \param double longitude
         \param double hight default 0.0
         */
-        public Coordinate(double _latetude, double _longitude,
+        public Coordinate(double _latitude, double _longitude,
                              double _height = 0.0)
         {
-            latetude = _latetude;
+            latitude = _latitude;
             longitude = _longitude;
             height = _height;
         }
@@ -57,7 +57,7 @@ namespace One_Sgp4
         */
         public string toString()
         {
-            string ret = "Lat: " + latetude +
+            string ret = "Lat: " + latitude +
                         " Long: " + longitude +
                         " Height: " + height;
             return ret;
@@ -67,9 +67,9 @@ namespace One_Sgp4
         /*!
         \return double Latetude
         */
-        public double getLatetude()
+        public double getLatitude()
         {
-            return latetude;
+            return latitude;
         }
 
         //! Returns the Longitude
@@ -106,7 +106,7 @@ namespace One_Sgp4
                 a = WGS_84.radiusEarthKM;
             }
             double srt = siderealTime + (toRadians * longitude);
-            double lat_rad = toRadians * latetude;
+            double lat_rad = toRadians * latitude;
             Point3d eciPos = new Point3d();
             //oblate earth
             double c = 1.0 / (Math.Sqrt(1.0 + f * (f - 2.0) *

--- a/One_Sgp4/sgp/Sgp4.cs
+++ b/One_Sgp4/sgp/Sgp4.cs
@@ -2015,7 +2015,7 @@ namespace One_Sgp4
 	        return 0;
         }
 
-        public List<Sgp4Data> getRestults()
+        public List<Sgp4Data> getResults()
         {
             return resultOrbitData;
         }

--- a/One_Sgp4/sgp/Sgp4Data.cs
+++ b/One_Sgp4/sgp/Sgp4Data.cs
@@ -121,7 +121,7 @@ namespace One_Sgp4
         /*!
         \return double x, y, z;
         */
-        public Point3d getPositonData()
+        public Point3d getPositionData()
         {
             return pos;
         }

--- a/One_Sgp4/time/EpochTime.cs
+++ b/One_Sgp4/time/EpochTime.cs
@@ -405,7 +405,8 @@ namespace One_Sgp4
             dayToDate(year, epoch);
             DateTime date = new DateTime(year, month, day, hour, minutes, Convert.ToInt32(Math.Floor(seconds)));
             date = date.AddMilliseconds((seconds - Math.Floor(seconds))*1000);
-            return date;
+            var newDate = DateTime.SpecifyKind(date, DateTimeKind.Utc);
+            return newDate;
         }
 
         //! Returns the Date and Time in JulianDate

--- a/Test/SatTest.cs
+++ b/Test/SatTest.cs
@@ -29,8 +29,8 @@ namespace Test
             Assert.Greater(ground.getHeight(), 0);
             Assert.LessOrEqual(ground.getLongitude(), 180.0);
             Assert.Greater(ground.getLongitude(), -180.0);
-            Assert.LessOrEqual(ground.getLatetude(), 90.0);
-            Assert.Greater(ground.getLatetude(), -90.0);
+            Assert.LessOrEqual(ground.getLatitude(), 90.0);
+            Assert.Greater(ground.getLatitude(), -90.0);
 
         }
 


### PR DESCRIPTION
* The dateTime kind should be specified to UTC in the EpochTime function toDateTime. If this is not done, the kind "not specified" is assumed by default which causes the time zone lag to be substracted multiple times on each conversion.  I added the specification which fixed the bug. 

* typos were fixed in the function and variable names.