### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The calculation are then done using the SGP4 class with the TLE-data and the WGS
 One_Sgp4.Sgp4 sgp4Propagator = new Sgp4(tleItem, Int<WGSCONSTANT>);
 sgp4Propagator.runSgp4Cal(startTime, stopTime, Double<calculation step in minutes>);
 List<One_Sgp4.Sgp4Data> resultDataList = new List<Sgp4Data>();
-resultDataList = sgp4Propagator.getRestults();
+resultDataList = sgp4Propagator.getResults();
 ```
 It is also possible to calculate the position of the Satellite at a single timepoint
 ```


### PR DESCRIPTION
Fixes #33

Correct a typo in the `README.md` file.

* Change `resultDataList = sgp4Propagator.getRestults();` to `resultDataList = sgp4Propagator.getResults();` in the code snippet.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/1manprojects/one_Sgp4/pull/34?shareId=1dd9f00a-11e4-48ed-bd40-c86a25424108).